### PR TITLE
Fix kind letter reuse (`m` for macros and modules)

### DIFF
--- a/.ctags
+++ b/.ctags
@@ -6,7 +6,7 @@
 --regex-Crystal=/^\s*macro\s+([a-z_][a-zA-Z0-9_?!]*)/\1/m,macro,macros/
 --regex-Crystal=/^\s*class\s+([A-Z][a-zA-Z0-9_:]*)/\1/c,class,classes/
 --regex-Crystal=/^\s*(abstract|private)\s+class\s+([A-Z][a-zA-Z0-9_:]*)/\1/c,class,classes/
---regex-Crystal=/^\s*module\s+([A-Z][a-zA-Z0-9_:]*)/\1/m,module,modules/
+--regex-Crystal=/^\s*module\s+([A-Z][a-zA-Z0-9_:]*)/\1/M,module,modules/
 --regex-Crystal=/^\s*lib\s+([A-Z][a-zA-Z0-9_:]*)/\1/l,lib,libs/
 --regex-Crystal=/^\s*struct\s+([A-Z][a-zA-Z0-9_:]*)/\1/s,struct,structs/
 --regex-Crystal=/^\s*(abstract|private)\s+struct\s+([A-Z][a-zA-Z0-9_:]*)/\2/s,struct,structs/


### PR DESCRIPTION
This fixes the ctags warning message 

```
ctags: Warning: Don't reuse the kind letter `m' in a language Crystal (old: "macro", new: "module")
```